### PR TITLE
chore: trigger changeset via github app

### DIFF
--- a/.github/workflows/on-push-to-main.yaml
+++ b/.github/workflows/on-push-to-main.yaml
@@ -33,10 +33,12 @@ jobs:
         run: npm install -g npm@latest
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
         with:
           app-id: ${{ secrets.CHANGESETS_APP_ID }}
           private-key: ${{ secrets.CHANGESETS_APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
       - name: Manage changesets
         uses: changesets/action@v1
         with:

--- a/.github/workflows/on-push-to-main.yaml
+++ b/.github/workflows/on-push-to-main.yaml
@@ -31,6 +31,12 @@ jobs:
         uses: ./.github/actions/install-dependencies
       - name: Update npm
         run: npm install -g npm@latest
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.CHANGESETS_APP_ID }}
+          private-key: ${{ secrets.CHANGESETS_APP_PRIVATE_KEY }}
       - name: Manage changesets
         uses: changesets/action@v1
         with:
@@ -40,4 +46,4 @@ jobs:
           title: "chore: publish package(s)"
           commitMode: "github-api"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI workflow updated to use a dedicated app-generated token for changesets operations, replacing the previous token source; this alters how automated release steps authenticate within the workflow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/enzymefinance/onyx-sdk/pull/43?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->